### PR TITLE
Team name automation

### DIFF
--- a/lib/mlb_gameday.rb
+++ b/lib/mlb_gameday.rb
@@ -34,13 +34,11 @@ module MLBGameday
     end
 
     def team(name)
-      return name if name.is_a? MLBGameday::Team
-
-      teams.each do |team|
-        return team if team.names.include? name.downcase
+      if name.is_a? MLBGameday::Team 
+        name
+      else
+        teams.select { |team| team.is_called?(name) }.first
       end
-
-      nil
     end
 
     def teams

--- a/lib/mlb_gameday/team.rb
+++ b/lib/mlb_gameday/team.rb
@@ -1,6 +1,6 @@
 module MLBGameday
   class Team
-    attr_reader :id, :name, :city, :league, :division, :names, :code, :file_code
+    attr_reader :id, :name, :city, :league, :division, :code, :file_code
 
     def initialize(opts = {})
       @id        = opts[:id]
@@ -8,14 +8,38 @@ module MLBGameday
       @city      = opts[:city]
       @league    = opts[:league]
       @division  = opts[:division]
-      @names     = opts[:names]
+      @alt_names = opts[:alt_names]
       @code      = opts[:code]
       @file_code = opts[:file_code]
+    end
+    
+    def full_name
+      "#{city} #{name}"
+    end
+    
+    def names
+      @names ||= (implicit_names + alt_names).uniq
     end
 
     # So we don't get huge printouts
     def inspect
       %(#<MLBGameday::Team @name="#{@name}">)
+    end
+    
+    private
+    def alt_names
+      @alt_names ||= []
+    end
+    
+    def implicit_names
+      result = strict_names << code.downcase
+      result << city.downcase unless ["New York", "Chicago"].include?(city)
+      
+      result
+    end
+    
+    def strict_names
+      [name, full_name].map(&:downcase)
     end
   end
 end

--- a/lib/mlb_gameday/team.rb
+++ b/lib/mlb_gameday/team.rb
@@ -37,6 +37,7 @@ module MLBGameday
     
     def implicit_names
       result = strict_names << code.downcase
+      result << singular_name.downcase if is_plural?
       result << city.downcase unless ["New York", "Chicago"].include?(city)
       
       result
@@ -44,6 +45,14 @@ module MLBGameday
     
     def strict_names
       [name, full_name].map(&:downcase)
+    end
+    
+    def singular_name
+      name.chomp('s')
+    end
+    
+    def is_plural?
+      singular_name != name
     end
   end
 end

--- a/lib/mlb_gameday/team.rb
+++ b/lib/mlb_gameday/team.rb
@@ -20,6 +20,10 @@ module MLBGameday
     def names
       @names ||= (implicit_names + alt_names).uniq
     end
+    
+    def is_called?(name)
+      names.include?(name.downcase)
+    end
 
     # So we don't get huge printouts
     def inspect

--- a/lib/mlb_gameday/team.rb
+++ b/lib/mlb_gameday/team.rb
@@ -36,11 +36,10 @@ module MLBGameday
     end
     
     def implicit_names
-      result = strict_names << code.downcase
-      result << singular_name.downcase if is_plural?
+      result = strict_names + [code, singular_name, despaced_name].map(&:downcase)
       result << city.downcase unless ["New York", "Chicago"].include?(city)
       
-      result
+      result.uniq
     end
     
     def strict_names
@@ -51,8 +50,8 @@ module MLBGameday
       name.chomp('s')
     end
     
-    def is_plural?
-      singular_name != name
+    def despaced_name
+      name.tr(' ', '')
     end
   end
 end

--- a/resources/data.yml
+++ b/resources/data.yml
@@ -15,11 +15,8 @@
           code: BAL
           file_code: bal
           id: 110
-          names:
-          - bal
-          - orioles
+          alt_names:
           - oriole
-          - baltimore
         :BOS: !ruby/object:MLBGameday::Team
           name: Red Sox
           city: Boston
@@ -28,11 +25,8 @@
           code: BOS
           file_code: bos
           id: 111
-          names:
-          - bos
-          - red sox
+          alt_names:
           - redsox
-          - boston
           - bosox
         :NYY: !ruby/object:MLBGameday::Team
           name: Yankees
@@ -42,11 +36,8 @@
           code: NYY
           file_code: nyy
           id: 147
-          names:
-          - nyy
-          - yankees
+          alt_names:
           - yankee
-          - new york yankees
           - new york yankee
         :TB: !ruby/object:MLBGameday::Team
           name: Rays
@@ -56,14 +47,11 @@
           code: TB
           file_code: tb
           id: 139
-          names:
-          - tb
-          - rays
+          alt_names:
           - ray
           - devil rays
           - devil ray
           - tampa
-          - tampa bay
         :TOR: !ruby/object:MLBGameday::Team
           name: Blue Jays
           city: Toronto
@@ -72,15 +60,12 @@
           code: TOR
           file_code: tor
           id: 141
-          names:
-          - tor
-          - blue jays
+          alt_names:
           - blue jay
           - bluejays
           - bluejay
           - jays
           - jay
-          - toronto
     :Central: &alcentral !ruby/object:MLBGameday::Division
       name: Central
       league: *al
@@ -94,11 +79,8 @@
           code: CLE
           file_code: cle
           id: 114
-          names:
-          - cle
-          - indians
+          alt_names:
           - indian
-          - cleveland
         :CWS: !ruby/object:MLBGameday::Team
           name: White Sox
           city: Chicago
@@ -107,10 +89,7 @@
           code: CWS
           file_code: cws
           id: 145
-          names:
-          - cws
-          - white sox
-          - chicago white sox
+          alt_names:
         :DET: !ruby/object:MLBGameday::Team
           name: Tigers
           city: Detroit
@@ -119,11 +98,8 @@
           code: DET
           file_code: det
           id: 116
-          names:
-          - det
-          - tigers
+          alt_names:
           - tiger
-          - detroit
         :KC: !ruby/object:MLBGameday::Team
           name: Royals
           city: Kansas City
@@ -132,11 +108,8 @@
           code: KC
           file_code: kc
           id: 118
-          names:
-          - kc
-          - royals
+          alt_names:
           - royal
-          - kansas city
           - kansas
         :MIN: !ruby/object:MLBGameday::Team
           name: Twins
@@ -146,11 +119,8 @@
           code: MIN
           file_code: min
           id: 142
-          names:
-          - min
-          - twins
+          alt_names:
           - twin
-          - minnesota
     :West: &alwest !ruby/object:MLBGameday::Division
       name: West
       league: *al
@@ -164,17 +134,13 @@
           code: LAA
           file_code: ana
           id: 108
-          names:
+          alt_names:
           - ana
-          - angels
           - angel
-          - anaheim
-          - ana
           - los angeles angel
           - los angeles angels
           - la angels
           - la angel
-          - laa
           - laaa
           - los angeles angels of anaheim
         :HOU: !ruby/object:MLBGameday::Team
@@ -185,11 +151,8 @@
           code: HOU
           file_code: hou
           id: 117
-          names:
-          - hou
-          - astros
+          alt_names:
           - astro
-          - houston
         :OAK: !ruby/object:MLBGameday::Team
           name: Athletics
           city: Oakland
@@ -198,12 +161,9 @@
           code: OAK
           file_code: oak
           id: 133
-          names:
-          - oak
-          - athletics
+          alt_names:
           - athletic
           - as
-          - oakland
         :SEA: !ruby/object:MLBGameday::Team
           name: Mariners
           city: Seattle
@@ -212,11 +172,8 @@
           code: SEA
           file_code: sea
           id: 136
-          names:
-          - sea
-          - mariners
+          alt_names:
           - mariner
-          - seattle
         :TEX: !ruby/object:MLBGameday::Team
           name: Rangers
           city: Texas
@@ -225,11 +182,8 @@
           code: TEX
           file_code: tex
           id: 140
-          names:
-          - tex
-          - rangers
+          alt_names:
           - ranger
-          - texas
 :NL: &nl !ruby/object:MLBGameday::League
   name: National
   divisions:
@@ -246,11 +200,8 @@
           code: ATL
           file_code: atl
           id: 144
-          names:
-          - atl
-          - braves
+          alt_names:
           - brave
-          - atlanta
         :MIA: !ruby/object:MLBGameday::Team
           name: Marlins
           city: Miami
@@ -259,11 +210,8 @@
           code: MIA
           file_code: mia
           id: 146
-          names:
-          - mia
-          - marlins
+          alt_names:
           - marlin
-          - miami
           - florida
         :NYM: !ruby/object:MLBGameday::Team
           name: Mets
@@ -273,11 +221,8 @@
           code: NYM
           file_code: nym
           id: 121
-          names:
-          - nym
-          - mets
+          alt_names:
           - met
-          - new york mets
           - new york met
         :PHI: !ruby/object:MLBGameday::Team
           name: Phillies
@@ -287,12 +232,9 @@
           code: PHI
           file_code: phi
           id: 143
-          names:
-          - phi
-          - phillies
+          alt_names:
           - phillie
           - philly
-          - philadelphia
         :WSH: !ruby/object:MLBGameday::Team
           name: Nationals
           city: Washington
@@ -301,12 +243,9 @@
           code: WSH
           file_code: was
           id: 120
-          names:
-          - wsh
-          - nationals
+          alt_names:
           - natinals
           - national
-          - washington
     :Central: &nlcentral !ruby/object:MLBGameday::Division
       name: Central
       league: *nl
@@ -320,11 +259,8 @@
           code: CHC
           file_code: chc
           id: 112
-          names:
-          - chc
-          - cubs
+          alt_names:
           - cub
-          - chicago cubs
           - chicago cub
         :CIN: !ruby/object:MLBGameday::Team
           name: Reds
@@ -334,11 +270,8 @@
           code: CIN
           file_code: cin
           id: 113
-          names:
-          - cin
-          - reds
+          alt_names:
           - red
-          - cincinnati
         :MIL: !ruby/object:MLBGameday::Team
           name: Brewers
           city: Milwaukee
@@ -347,11 +280,8 @@
           code: MIL
           file_code: mil
           id: 158
-          names:
-          - mil
-          - brewers
+          alt_names:
           - brewer
-          - milwaukee
         :PIT: !ruby/object:MLBGameday::Team
           name: Pirates
           city: Pittsburgh
@@ -360,13 +290,10 @@
           code: PIT
           file_code: pit
           id: 134
-          names:
-          - pit
-          - pirates
+          alt_names:
           - pirate
           - buccos
           - bucco
-          - pittsburgh
         :STL: !ruby/object:MLBGameday::Team
           name: Cardinals
           city: St. Louis
@@ -375,12 +302,9 @@
           code: STL
           file_code: stl
           id: 138
-          names:
-          - stl
-          - cardinals
+          alt_names:
           - cardinal
           - st louis
-          - st. louis
     :West: &nlwest !ruby/object:MLBGameday::Division
       name: West
       league: *nl
@@ -394,13 +318,10 @@
           code: ARI
           file_code: ari
           id: 109
-          names:
-          - ari
-          - diamondbacks
+          alt_names:
           - diamondback
           - dbacks
           - dback
-          - arizona
           - az
         :COL: !ruby/object:MLBGameday::Team
           name: Rockies
@@ -410,11 +331,8 @@
           code: COL
           file_code: col
           id: 115
-          names:
-          - col
-          - rockies
+          alt_names:
           - rockie
-          - colorado
         :LAD: !ruby/object:MLBGameday::Team
           name: Dodgers
           city: Los Angeles
@@ -423,11 +341,8 @@
           code: LAD
           file_code: la
           id: 119
-          names:
-          - lad
-          - dodgers
+          alt_names:
           - dodger
-          - los angeles
           - la
           - los angeles dodgers
           - los angeles dodger
@@ -441,11 +356,8 @@
           code: SD
           file_code: sd
           id: 135
-          names:
-          - sd
-          - padres
+          alt_names:
           - padre
-          - san diego
         :SF: !ruby/object:MLBGameday::Team
           name: Giants
           city: San Francisco
@@ -454,10 +366,7 @@
           code: SF
           file_code: sf
           id: 137
-          names:
-          - sf
-          - giants
+          alt_names:
           - giant
           - san fran
-          - san francisco
           - gigantes

--- a/resources/data.yml
+++ b/resources/data.yml
@@ -15,7 +15,6 @@
           code: BAL
           file_code: bal
           id: 110
-          alt_names:
         :BOS: !ruby/object:MLBGameday::Team
           name: Red Sox
           city: Boston
@@ -75,7 +74,6 @@
           code: CLE
           file_code: cle
           id: 114
-          alt_names:
         :CWS: !ruby/object:MLBGameday::Team
           name: White Sox
           city: Chicago
@@ -84,7 +82,6 @@
           code: CWS
           file_code: cws
           id: 145
-          alt_names:
         :DET: !ruby/object:MLBGameday::Team
           name: Tigers
           city: Detroit
@@ -93,7 +90,6 @@
           code: DET
           file_code: det
           id: 116
-          alt_names:
         :KC: !ruby/object:MLBGameday::Team
           name: Royals
           city: Kansas City
@@ -112,7 +108,6 @@
           code: MIN
           file_code: min
           id: 142
-          alt_names:
     :West: &alwest !ruby/object:MLBGameday::Division
       name: West
       league: *al
@@ -142,7 +137,6 @@
           code: HOU
           file_code: hou
           id: 117
-          alt_names:
         :OAK: !ruby/object:MLBGameday::Team
           name: Athletics
           city: Oakland
@@ -161,7 +155,6 @@
           code: SEA
           file_code: sea
           id: 136
-          alt_names:
         :TEX: !ruby/object:MLBGameday::Team
           name: Rangers
           city: Texas
@@ -170,7 +163,6 @@
           code: TEX
           file_code: tex
           id: 140
-          alt_names:
 :NL: &nl !ruby/object:MLBGameday::League
   name: National
   divisions:
@@ -187,7 +179,6 @@
           code: ATL
           file_code: atl
           id: 144
-          alt_names:
         :MIA: !ruby/object:MLBGameday::Team
           name: Marlins
           city: Miami
@@ -251,7 +242,6 @@
           code: CIN
           file_code: cin
           id: 113
-          alt_names:
         :MIL: !ruby/object:MLBGameday::Team
           name: Brewers
           city: Milwaukee
@@ -260,7 +250,6 @@
           code: MIL
           file_code: mil
           id: 158
-          alt_names:
         :PIT: !ruby/object:MLBGameday::Team
           name: Pirates
           city: Pittsburgh
@@ -307,7 +296,6 @@
           code: COL
           file_code: col
           id: 115
-          alt_names:
         :LAD: !ruby/object:MLBGameday::Team
           name: Dodgers
           city: Los Angeles
@@ -330,7 +318,6 @@
           code: SD
           file_code: sd
           id: 135
-          alt_names:
         :SF: !ruby/object:MLBGameday::Team
           name: Giants
           city: San Francisco

--- a/resources/data.yml
+++ b/resources/data.yml
@@ -16,7 +16,6 @@
           file_code: bal
           id: 110
           alt_names:
-          - oriole
         :BOS: !ruby/object:MLBGameday::Team
           name: Red Sox
           city: Boston
@@ -37,7 +36,6 @@
           file_code: nyy
           id: 147
           alt_names:
-          - yankee
           - new york yankee
         :TB: !ruby/object:MLBGameday::Team
           name: Rays
@@ -48,7 +46,6 @@
           file_code: tb
           id: 139
           alt_names:
-          - ray
           - devil rays
           - devil ray
           - tampa
@@ -61,7 +58,6 @@
           file_code: tor
           id: 141
           alt_names:
-          - blue jay
           - bluejays
           - bluejay
           - jays
@@ -80,7 +76,6 @@
           file_code: cle
           id: 114
           alt_names:
-          - indian
         :CWS: !ruby/object:MLBGameday::Team
           name: White Sox
           city: Chicago
@@ -99,7 +94,6 @@
           file_code: det
           id: 116
           alt_names:
-          - tiger
         :KC: !ruby/object:MLBGameday::Team
           name: Royals
           city: Kansas City
@@ -109,7 +103,6 @@
           file_code: kc
           id: 118
           alt_names:
-          - royal
           - kansas
         :MIN: !ruby/object:MLBGameday::Team
           name: Twins
@@ -120,7 +113,6 @@
           file_code: min
           id: 142
           alt_names:
-          - twin
     :West: &alwest !ruby/object:MLBGameday::Division
       name: West
       league: *al
@@ -136,7 +128,6 @@
           id: 108
           alt_names:
           - ana
-          - angel
           - los angeles angel
           - los angeles angels
           - la angels
@@ -152,7 +143,6 @@
           file_code: hou
           id: 117
           alt_names:
-          - astro
         :OAK: !ruby/object:MLBGameday::Team
           name: Athletics
           city: Oakland
@@ -162,7 +152,6 @@
           file_code: oak
           id: 133
           alt_names:
-          - athletic
           - as
         :SEA: !ruby/object:MLBGameday::Team
           name: Mariners
@@ -173,7 +162,6 @@
           file_code: sea
           id: 136
           alt_names:
-          - mariner
         :TEX: !ruby/object:MLBGameday::Team
           name: Rangers
           city: Texas
@@ -183,7 +171,6 @@
           file_code: tex
           id: 140
           alt_names:
-          - ranger
 :NL: &nl !ruby/object:MLBGameday::League
   name: National
   divisions:
@@ -201,7 +188,6 @@
           file_code: atl
           id: 144
           alt_names:
-          - brave
         :MIA: !ruby/object:MLBGameday::Team
           name: Marlins
           city: Miami
@@ -211,7 +197,6 @@
           file_code: mia
           id: 146
           alt_names:
-          - marlin
           - florida
         :NYM: !ruby/object:MLBGameday::Team
           name: Mets
@@ -222,7 +207,6 @@
           file_code: nym
           id: 121
           alt_names:
-          - met
           - new york met
         :PHI: !ruby/object:MLBGameday::Team
           name: Phillies
@@ -233,7 +217,6 @@
           file_code: phi
           id: 143
           alt_names:
-          - phillie
           - philly
         :WSH: !ruby/object:MLBGameday::Team
           name: Nationals
@@ -245,7 +228,6 @@
           id: 120
           alt_names:
           - natinals
-          - national
     :Central: &nlcentral !ruby/object:MLBGameday::Division
       name: Central
       league: *nl
@@ -260,7 +242,6 @@
           file_code: chc
           id: 112
           alt_names:
-          - cub
           - chicago cub
         :CIN: !ruby/object:MLBGameday::Team
           name: Reds
@@ -271,7 +252,6 @@
           file_code: cin
           id: 113
           alt_names:
-          - red
         :MIL: !ruby/object:MLBGameday::Team
           name: Brewers
           city: Milwaukee
@@ -281,7 +261,6 @@
           file_code: mil
           id: 158
           alt_names:
-          - brewer
         :PIT: !ruby/object:MLBGameday::Team
           name: Pirates
           city: Pittsburgh
@@ -291,7 +270,6 @@
           file_code: pit
           id: 134
           alt_names:
-          - pirate
           - buccos
           - bucco
         :STL: !ruby/object:MLBGameday::Team
@@ -303,7 +281,6 @@
           file_code: stl
           id: 138
           alt_names:
-          - cardinal
           - st louis
     :West: &nlwest !ruby/object:MLBGameday::Division
       name: West
@@ -319,7 +296,6 @@
           file_code: ari
           id: 109
           alt_names:
-          - diamondback
           - dbacks
           - dback
           - az
@@ -332,7 +308,6 @@
           file_code: col
           id: 115
           alt_names:
-          - rockie
         :LAD: !ruby/object:MLBGameday::Team
           name: Dodgers
           city: Los Angeles
@@ -342,7 +317,6 @@
           file_code: la
           id: 119
           alt_names:
-          - dodger
           - la
           - los angeles dodgers
           - los angeles dodger
@@ -357,7 +331,6 @@
           file_code: sd
           id: 135
           alt_names:
-          - padre
         :SF: !ruby/object:MLBGameday::Team
           name: Giants
           city: San Francisco
@@ -367,6 +340,5 @@
           file_code: sf
           id: 137
           alt_names:
-          - giant
           - san fran
           - gigantes

--- a/resources/data.yml
+++ b/resources/data.yml
@@ -24,7 +24,6 @@
           file_code: bos
           id: 111
           alt_names:
-          - redsox
           - bosox
         :NYY: !ruby/object:MLBGameday::Team
           name: Yankees
@@ -57,7 +56,6 @@
           file_code: tor
           id: 141
           alt_names:
-          - bluejays
           - bluejay
           - jays
           - jay

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -38,4 +38,20 @@ class TestApi < MiniTest::Test
     assert_equal @api.team('Astros').league.name, 'American'
     assert_equal @api.team('Astros').division.name, 'West'
   end
+
+  def test_names_includes_code
+    assert_includes @api.team('Oakland').names, 'oak'
+  end
+
+  def test_names_includes_name
+    assert_includes @api.team('Oakland').names, 'athletics'
+  end
+
+  def test_names_includes_alt_names
+    assert_includes @api.team('Oakland').names, 'as'
+  end
+
+  def test_names_includes_city_except_nyc_and_chicago
+    assert_includes @api.team('Athletics').names, 'oakland'
+  end
 end

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -30,6 +30,10 @@ class TestApi < MiniTest::Test
     assert_equal @api.team('Dodgers').city, 'Los Angeles'
   end
 
+  def test_name_search_for_nonexistent_returns_nil
+    assert_nil @api.team('Senators')
+  end
+
   def test_division_team_count
     assert_equal @api.team('Dodgers').division.teams.count, 5
   end

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -51,6 +51,14 @@ class TestApi < MiniTest::Test
     end
   end
 
+  def test_names_includes_alt_names
+    @api.teams.each do |team|
+      team.send(:alt_names).each do |alt_name|
+        assert_includes team.names, alt_name.downcase
+      end
+    end
+  end
+
   def test_names_includes_city_except_nyc_and_chicago
     @api.teams.reject {|team| ["New York", "Chicago"].include?(team.city)}.each do |team|
         assert_includes team.names, team.city.downcase

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -68,6 +68,12 @@ class TestApi < MiniTest::Test
       assert_includes team.names, team.send(:singular_name).downcase
     end
   end
+  
+  def test_names_includes_despaced_name_when_name_is_multi_word
+    @api.teams.select {|team| team.name.split.size > 1}.each do |team|
+        assert_includes team.names, team.send(:despaced_name).downcase
+    end
+  end
 
   def test_names_includes_city_except_nyc_and_chicago
     @api.teams.reject {|team| ["New York", "Chicago"].include?(team.city)}.each do |team|

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -70,4 +70,12 @@ class TestApi < MiniTest::Test
         refute_includes team.names, team.city.downcase
     end
   end
+  
+  def test_no_teams_share_any_names
+    @api.teams.each do |team|
+      @api.teams.select {|t| t != team}.each do |other_team|
+        assert_equal (team.names - other_team.names), team.names
+      end
+    end
+  end
 end

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -62,6 +62,12 @@ class TestApi < MiniTest::Test
       end
     end
   end
+  
+  def test_names_include_singular_name_when_different_from_name
+    @api.teams.reject {|team| team.name == team.send(:singular_name)}.each do |team|
+      assert_includes team.names, team.send(:singular_name).downcase
+    end
+  end
 
   def test_names_includes_city_except_nyc_and_chicago
     @api.teams.reject {|team| ["New York", "Chicago"].include?(team.city)}.each do |team|

--- a/test/api_spec.rb
+++ b/test/api_spec.rb
@@ -40,18 +40,26 @@ class TestApi < MiniTest::Test
   end
 
   def test_names_includes_code
-    assert_includes @api.team('Oakland').names, 'oak'
+    @api.teams.each do |team|
+      assert_includes team.names, team.code.downcase
+    end
   end
 
   def test_names_includes_name
-    assert_includes @api.team('Oakland').names, 'athletics'
-  end
-
-  def test_names_includes_alt_names
-    assert_includes @api.team('Oakland').names, 'as'
+    @api.teams.each do |team|
+      assert_includes team.names, team.name.downcase
+    end
   end
 
   def test_names_includes_city_except_nyc_and_chicago
-    assert_includes @api.team('Athletics').names, 'oakland'
+    @api.teams.reject {|team| ["New York", "Chicago"].include?(team.city)}.each do |team|
+        assert_includes team.names, team.city.downcase
+    end
+  end
+
+  def test_names_does_not_include_city_for_nyc_and_chicago
+    @api.teams.select {|team| ["New York", "Chicago"].include?(team.city)}.each do |team|
+        refute_includes team.names, team.city.downcase
+    end
   end
 end


### PR DESCRIPTION
I needed a ruby gem to convert full team name (e.g. "Oakland Athletics") to common MLB abbreviation (e.g. "OAK"), and mlb_gameday almost fits the bill except that the data in data.yml didn't consistently have full team name. Rather than just type them all in, I chose to DRY up the datafile by adding the missing types names on the fly.

Replaces 151 lines from data.yml with 34 lines of code and 56 lines of test code.