### PR TITLE
Flattened implicit_names array

### DIFF
--- a/lib/mlb_gameday/team.rb
+++ b/lib/mlb_gameday/team.rb
@@ -42,7 +42,7 @@ module MLBGameday
       result << [code, singular_name, despaced_name].map(&:downcase)
       result << city.downcase unless ['New York', 'Chicago'].include?(city)
 
-      result.uniq
+      result.flatten.uniq
     end
 
     def strict_names


### PR DESCRIPTION
This fixes the team name search. 

[These Changes](https://github.com/Fustrate/mlb_gameday/blob/master/lib/mlb_gameday/team.rb#L42) introduced a bug that turned team names into nested arrays like:
`["orioles", "baltimore orioles", ["bal", "oriole", "orioles"], "baltimore", "balmlb"]`
